### PR TITLE
Root cause add error fixes

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-28T08:41:54.443Z\n"
-"PO-Revision-Date: 2022-03-28T08:41:54.443Z\n"
+"POT-Creation-Date: 2022-04-05T07:06:30.329Z\n"
+"PO-Revision-Date: 2022-04-05T07:06:30.329Z\n"
 
 msgid "No Access"
 msgstr "No Access"
@@ -1003,6 +1003,9 @@ msgstr "Choropleth Layer"
 
 msgid "Bubble Layer"
 msgstr "Bubble Layer"
+
+msgid "This indicator has no configured legends"
+msgstr "This indicator has no configured legends"
 
 msgid "Select"
 msgstr "Select"

--- a/src/modules/Migration/services/migrate.ts
+++ b/src/modules/Migration/services/migrate.ts
@@ -264,11 +264,7 @@ function convertRootCauseData(data: any, config: any) {
 }
 
 export async function migrateRootCauseDataByIntervention(engine: any, interventionId: string, config: any) {
-  const rootCauseData = await getRootCausesData(engine, interventionId);
-  if (!isEmpty(rootCauseData)) {
-    const convertedData = rootCauseData.map((data: any) => convertRootCauseData(data, config));
-    return await migrateRootCauseData(engine, `${interventionId}_${ROOT_CAUSE_SUFFIX}`, convertedData);
-  } else {
-    return await migrateRootCauseData(engine, `${interventionId}_${ROOT_CAUSE_SUFFIX}`, []);
-  }
+  const rootCauseData = (await getRootCausesData(engine, interventionId)) ?? [];
+  const convertedData = rootCauseData?.map((data: any) => convertRootCauseData(data, config)) ?? [];
+  return await migrateRootCauseData(engine, `${interventionId}_${ROOT_CAUSE_SUFFIX}`, convertedData);
 }

--- a/src/modules/Migration/services/migrate.ts
+++ b/src/modules/Migration/services/migrate.ts
@@ -268,5 +268,7 @@ export async function migrateRootCauseDataByIntervention(engine: any, interventi
   if (!isEmpty(rootCauseData)) {
     const convertedData = rootCauseData.map((data: any) => convertRootCauseData(data, config));
     return await migrateRootCauseData(engine, `${interventionId}_${ROOT_CAUSE_SUFFIX}`, convertedData);
+  } else {
+    return await migrateRootCauseData(engine, `${interventionId}_${ROOT_CAUSE_SUFFIX}`, []);
   }
 }


### PR DESCRIPTION
- Fixed issues with missing root cause key throwing error when a user creates a new root cause
- Passed an empty array for root cause migration if there were no root causes defined for the intervention