### PR TITLE
✨ Determinant color reset implementation

### DIFF
--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -18,6 +18,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       {
         id: uid(),
         name: i18n.t("Commodities"),
+        code: "commodities",
         items: [],
         style: {
           color: "#7DB2E8",
@@ -26,6 +27,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       },
       {
         id: uid(),
+        code: "humanResources",
         name: i18n.t("Human Resources"),
         items: [],
         style: {
@@ -35,6 +37,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       },
       {
         id: uid(),
+        code: "geographicAccessibility",
         name: i18n.t("Geographic Accessibility"),
         items: [],
         style: {
@@ -44,6 +47,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       },
       {
         id: uid(),
+        code: "initialUtilization",
         name: i18n.t("Initial Utilisation"),
         items: [],
         style: {
@@ -53,6 +57,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       },
       {
         id: uid(),
+        code: "continuousUtilization",
         name: i18n.t("Continuous Utilisation"),
         items: [],
         style: {
@@ -62,6 +67,7 @@ export const DEFAULT_INTERVENTION_CONFIG: InterventionConfig = {
       },
       {
         id: uid(),
+        code: "effectiveCoverage",
         name: i18n.t("Effective Coverage"),
         items: [],
         style: {

--- a/src/modules/InterventionConfiguration/components/Determinants/components/DeterminantArea/component/ColorPicker.tsx
+++ b/src/modules/InterventionConfiguration/components/Determinants/components/DeterminantArea/component/ColorPicker.tsx
@@ -1,33 +1,66 @@
-import { colors, Popover } from "@dhis2/ui";
-import React, { useState } from "react";
+import { Button, colors, Popover } from "@dhis2/ui";
+import React, { useCallback, useState } from "react";
 import { SketchPicker } from "react-color";
+import { Group } from "../../../../../../../shared/interfaces/interventionConfig";
+import { find, get } from "lodash";
+import { DEFAULT_INTERVENTION_CONFIG } from "../../../../../../../constants/defaults";
 
 type ColorPickerProps = {
   reference: EventTarget;
   value: any;
   onClose: () => void;
+  onReset: () => void;
   onChange: (value: any) => void;
 };
 
-function ColorPickerPopper({ reference, value, onClose, onChange }: ColorPickerProps) {
+function ColorPickerPopper({ reference, value, onClose, onChange, onReset }: ColorPickerProps) {
   return (
     <Popover reference={reference} placement="auto" strategy="fixed" className="popper" onClickOutside={onClose}>
-      <SketchPicker
-        color={
-          // @ts-ignore
-          { hex: value }
-        }
-        onChange={(color: { hex: any }) => {
-          onChange(color.hex);
-          onClose();
-        }}
-      />
+      <div className="column gap p-8">
+        <SketchPicker
+          color={
+            // @ts-ignore
+            { hex: value }
+          }
+          onChange={(color: { hex: any }) => {
+            onChange(color.hex);
+            onClose();
+          }}
+        />
+        <Button
+          onClick={(value: any, e: { stopPropagation: () => void }) => {
+            e.stopPropagation();
+            onReset();
+          }}>
+          Reset
+        </Button>
+      </div>
     </Popover>
   );
 }
 
-export default function ColorPicker({ color, onChange }: { color?: string; onChange: (color: string) => void }): React.ReactElement {
+function getDefaultColor(group: Group) {
+  const defaultGroups = get(DEFAULT_INTERVENTION_CONFIG, `dataSelection.groups`);
+  const defaultGroup = find(defaultGroups, (g: Group) => {
+    if (group.code) {
+      return g.code === group.code;
+    }
+    return g.sortOrder === group.sortOrder;
+  });
+
+  console.log({ defaultGroup, group });
+  if (defaultGroup) {
+    return defaultGroup?.style?.color;
+  }
+  return colors.grey600;
+}
+
+export default function ColorPicker({ onChange, group }: { color?: string; onChange: (color: string) => void; group: Group }): React.ReactElement {
   const [reference, setReference] = useState<EventTarget | undefined>(undefined);
+  const color = group?.style?.color ?? getDefaultColor(group);
+  const onReset = useCallback(() => {
+    onChange(getDefaultColor(group));
+  }, [group]);
 
   return (
     <>
@@ -40,7 +73,7 @@ export default function ColorPicker({ color, onChange }: { color?: string; onCha
         style={{ background: color, borderColor: colors.grey500, width: 80 }}
         className={"legend-color"}
       />
-      {reference && <ColorPickerPopper onClose={() => setReference(undefined)} reference={reference} value={color} onChange={onChange} />}
+      {reference && <ColorPickerPopper onReset={onReset} onClose={() => setReference(undefined)} reference={reference} value={color} onChange={onChange} />}
     </>
   );
 }

--- a/src/modules/InterventionConfiguration/components/Determinants/components/DeterminantArea/component/Determinants.tsx
+++ b/src/modules/InterventionConfiguration/components/Determinants/components/DeterminantArea/component/Determinants.tsx
@@ -26,11 +26,13 @@ export default function GroupDeterminantComponent(): React.ReactElement {
 
   const { confirm } = useConfirmDialog();
 
-  const groups: Array<any> = determinants?.map(({ id, name, items, style }: Group) => {
+  const groups: Array<any> = determinants?.map((group: Group) => {
+    const { id, name, items, style } = group ?? {};
     if (!isArray(determinants)) {
       return [];
     }
     return {
+      ...group,
       id,
       name: `${name} (${items.length})`,
       items: items?.map(({ id, type, label }: DataItem) => ({
@@ -110,7 +112,7 @@ export default function GroupDeterminantComponent(): React.ReactElement {
           const groupIndex = findIndex(groups, { id });
           return (
             <ColorPicker
-              color={groups[groupIndex].style?.color}
+              group={groups[groupIndex]}
               onChange={(color) => {
                 setValue(`dataSelection.groups.${groupIndex}.style.color`, color);
               }}

--- a/src/modules/Migration/services/migrate.ts
+++ b/src/modules/Migration/services/migrate.ts
@@ -1,5 +1,5 @@
 import { map } from "async";
-import { compact, filter, find, isEmpty, last } from "lodash";
+import { camelCase, compact, filter, find, isEmpty, last } from "lodash";
 import { BNA_NAMESPACE, BNA_ROOT_CAUSE_NAMESPACE, ROOT_CAUSE_CONFIG_KEY, ROOT_CAUSE_SUFFIX } from "../../../constants/dataStore";
 import {
   DataItem,
@@ -100,6 +100,7 @@ function convertData(customFunctions: Array<CustomFunction>, dataConfig?: Global
         sortOrder,
         style: { color },
         items: compact(groupItems),
+        code: camelCase(name),
       };
     });
     const newLegendDefinitions: Array<LegendDefinition> = legendDefinitions?.map(({ id, name, color, default: isDefault }: Legend) => {

--- a/src/shared/interfaces/interventionConfig.ts
+++ b/src/shared/interfaces/interventionConfig.ts
@@ -62,6 +62,7 @@ export interface DataItem {
 export interface Group {
   id: string;
   name: string;
+  code: string;
   style?: { color: string };
   items: Array<DataItem>;
   sortOrder: number;


### PR DESCRIPTION
- Added color reset to default button in determinant configuration
 - Added `code` to Determinant interface

BREAKING CHANGE: All previously migrated/configured interventions will miss the `code` key in the determinants. Re-migration is advised